### PR TITLE
Do not wrap requests that skip the request filter

### DIFF
--- a/src/Website/Api/ContentHandlers.cs
+++ b/src/Website/Api/ContentHandlers.cs
@@ -71,7 +71,19 @@ namespace Website {
             return false; //it's a partial
         }
 
-        protected void RegisterFilter() {
+        protected void RegisterFilter()
+        {
+            var runResponseMiddleware = "X-Run-Response-Middleware";
+
+            Application.Current.Use((Request request) => {
+                //Mark this request to be wrapped by Website response middleware.
+                //Without this we would wrap ALL requests, including the ones that shouldn't be wrapped
+                //(e.g. "Sign out" button in SignIn app, which uses HandlerOptions.SkipRequestFilters = true)
+                //Remove this when we have a flag to disable all middleware
+                request.Headers[runResponseMiddleware] = "Yes";
+                return null;
+            });
+
             Application.Current.Use((Request request, Response response) => {
                 if (!(response.Resource is Json))
                 {
@@ -79,6 +91,11 @@ namespace Website {
                 }
 
                 if (request.Uri.StartsWith("/website/cms")) {
+                    return response;
+                }
+
+                if (request.Headers[runResponseMiddleware] == null)
+                {
                     return response;
                 }
 


### PR DESCRIPTION
Fixes issue #20.

"Sign out" button in the sign in app uses a flag `HandlerOptions.SkipRequestFilters`. Website app uses a **response** filter though, and this flag does not skip that one.

In result, Website app wraps a request that should not be wrapped.

The solution requires a custom HTTP header applied in the **request** middleware that will force skipping of the **response** middleware.

This is the same fix as https://github.com/StarcounterPrefabs/Launcher/commit/39da52caab8b6f9275d05d97d0e4cac6794d71d0

I consider this to be a temporary solution until there is a flag `SkipMiddleware`, which skips both the request and the response filter.